### PR TITLE
add `lilypond_notation()` method to `Chord` class

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,14 @@ Now let's try some advanced stuff: given a list of chords, find all scales that 
 
 If you have [lilypond](http://lilypond.org/) installed, you can make little melodies using this program, an example is given in 'lilypond_example.py'
 
+Running Tests
+=============
+
+From the project root directory, run:
+
+```
+python -m tests.tests
+```
 
 Contributors
 ============

--- a/musthe/musthe.py
+++ b/musthe/musthe.py
@@ -8,6 +8,7 @@ Federico Ferri <federico.ferri.it@gmail.com>
 """
 
 import re
+from typing import Union
 
 
 def UnsupportedOperands(op, type1, type2):
@@ -332,6 +333,20 @@ class Chord:
         'ø7':     'm7dim5',
         'm7b5':   'm7dim5',
     }
+    
+    lilypond_modifiers = {
+        'maj': None,
+        'min': 'm',
+        'dom7': '7',
+        'min7': 'm7',
+        'm7dim5': '7.5-',
+        'open5':  '1.5.8',        
+    }
+    """Maps Musthe chord modifiers to their LilyPond `\chordmode` equivalents. Any items
+    omitted from this list (``min``, ``aug`` and ``dim``, for example) are
+    assumed to use the same value in LilyPond.
+    """
+
     valid_types = list(recipes.keys()) + list(aliases.keys())
 
     @staticmethod
@@ -379,6 +394,30 @@ class Chord:
         else:
             return all(self.notes[i] == other.notes[i]
                        for i in range(len(self.notes)))
+    
+    def lilypond_notation(self, duration: Union[str,int] = ""):
+        """Returns the chord as string that can be used in a LilyPond
+        ``\chordmode`` block.
+        
+        Examples:
+            >>> Chord(Note('C')).lilypond_notation()
+            'c'
+
+            >>> Chord(Note('G#'), 'dom7').lilypond_notation(4)
+            'gis4:7'
+
+            >>> Chord(Note('Eb'), 'open5').lilypond_notation('8.')
+            'ees8.:1.5.8'            
+        """
+
+        # Get the chord root lilypond_format() string
+        root = f"{self.notes[0].lilypond_notation()}"
+        if self.chord_type in self.lilypond_modifiers.keys():
+            modifier = self.lilypond_modifiers[self.chord_type]
+        else:
+            modifier = self.chord_type
+        
+        return f"{root}{duration}:{modifier}" if modifier is not None else f"{root}{duration}"
 
 
 class Scale:

--- a/musthe/musthe.py
+++ b/musthe/musthe.py
@@ -334,6 +334,10 @@ class Chord:
         'm7b5':   'm7dim5',
     }
     
+    """Maps Musthe chord modifiers to their LilyPond `\chordmode` equivalents. Any items
+    omitted from this list (``min``, ``aug`` and ``dim``, for example) are
+    assumed to use the same value in LilyPond.
+    """
     lilypond_modifiers = {
         'maj': None,
         'min': 'm',
@@ -342,10 +346,6 @@ class Chord:
         'm7dim5': '7.5-',
         'open5':  '1.5.8',        
     }
-    """Maps Musthe chord modifiers to their LilyPond `\chordmode` equivalents. Any items
-    omitted from this list (``min``, ``aug`` and ``dim``, for example) are
-    assumed to use the same value in LilyPond.
-    """
 
     valid_types = list(recipes.keys()) + list(aliases.keys())
 
@@ -395,11 +395,22 @@ class Chord:
             return all(self.notes[i] == other.notes[i]
                        for i in range(len(self.notes)))
     
-    def lilypond_notation(self, duration: Union[str,int] = ""):
+    def lilypond_notation(self, duration: Union[str, int] = "") -> str:
         """Returns the chord as string that can be used in a LilyPond
         ``\chordmode`` block.
         
-        Examples:
+        Parameters
+        ----------
+        duration : Union[str, int]
+            A LilyPond note duration, where `1` is a whole note, `2` is a half note, `4` is a quarter note, et cetera. For a dotted note, include a `.` after the number. (See https://lilypond.org/doc/latest/Documentation/notation/durations.)
+
+        Returns
+        -------
+        str
+            A ``str`` representing the chord in LilyPond chord notation. (See: https://lilypond.org/doc/latest/Documentation/notation/chord-notation)
+
+        Examples
+        --------
             >>> Chord(Note('C')).lilypond_notation()
             'c'
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -307,16 +307,20 @@ class TestsForChord(unittest.TestCase):
     def test_lilypond_accidentals(self):
         """Tests LilyPond chord notation with accidentals.
         """
-        self.assertEqual(Chord(Note('C'), 'maj7').lilypond_notation(), 'c:maj7')
-        self.assertEqual(Chord(Note('D'), 'aug').lilypond_notation(1), 'd1:aug')
-        self.assertEqual(Chord(Note('E'), 'dim').lilypond_notation(2), 'e2:dim')
-        self.assertEqual(Chord(Note('F'), 'maj7').lilypond_notation(4), 'f4:maj7')
-        self.assertEqual(Chord(Note('G'), 'aug7').lilypond_notation(8), 'g8:aug7')
-        self.assertEqual(Chord(Note('A'), 'dim7').lilypond_notation(16), 'a16:dim7')
-        self.assertEqual(Chord(Note('B'), 'sus2').lilypond_notation('2.'), 'b2.:sus2')
-        self.assertEqual(Chord(Note('C'), 'sus4').lilypond_notation('4.'), 'c4.:sus4')
-        self.assertEqual(Chord(Note('D'), 'aug').lilypond_notation('8.'), 'd8.:aug')
-        self.assertEqual(Chord(Note('E'), 'dim').lilypond_notation('16.'), 'e16.:dim')
+        self.assertEqual(Chord(Note('Cb'), 'aug').lilypond_notation('1'), 'ces1:aug')
+        self.assertEqual(Chord(Note('C#'), 'dim').lilypond_notation('2'), 'cis2:dim')
+        self.assertEqual(Chord(Note('Db'), 'maj7').lilypond_notation('4'), 'des4:maj7')
+        self.assertEqual(Chord(Note('D#'), 'aug7').lilypond_notation('8'), 'dis8:aug7')
+        self.assertEqual(Chord(Note('Eb'), 'dim7').lilypond_notation('16'), 'ees16:dim7')
+        self.assertEqual(Chord(Note('E#'), 'sus2').lilypond_notation('2.'), 'eis2.:sus2')
+        self.assertEqual(Chord(Note('Fb'), 'sus4').lilypond_notation('4.'), 'fes4.:sus4')
+        self.assertEqual(Chord(Note('F#'), 'maj9').lilypond_notation('8.'), 'fis8.:maj9')
+        self.assertEqual(Chord(Note('Gb'), 'aug9').lilypond_notation('16.'), 'ges16.:aug9')
+        self.assertEqual(Chord(Note('G#'), 'dim9').lilypond_notation('1'), 'gis1:dim9')
+        self.assertEqual(Chord(Note('Ab'), 'aug').lilypond_notation('2'), 'aes2:aug')
+        self.assertEqual(Chord(Note('A#'), 'dim').lilypond_notation('4'), 'ais4:dim')
+        self.assertEqual(Chord(Note('Bb'), 'maj7').lilypond_notation('8'), 'bes8:maj7')
+        self.assertEqual(Chord(Note('B#'), 'aug7').lilypond_notation('16'), 'bis16:aug7')
 
     def test_lilypond_mod_same(self):
         """Tests LilyPond chord notation where the Musthe and LilyPond chord

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -303,16 +303,29 @@ class TestsForChord(unittest.TestCase):
     def test_lilypond_accidentals(self):
         """Tests LilyPond chord notation with accidentals.
         """
-        self.assertEqual(Chord(Note('G#')).lilypond_notation(), 'gis')
-        self.assertEqual(Chord(Note('Ab')).lilypond_notation(), 'aes')
+        self.assertEqual(Chord(Note('C'), 'maj7').lilypond_notation(), 'c:maj7')
+        self.assertEqual(Chord(Note('D'), 'aug').lilypond_notation(1), 'd1:aug')
+        self.assertEqual(Chord(Note('E'), 'dim').lilypond_notation(2), 'e2:dim')
+        self.assertEqual(Chord(Note('F'), 'maj7').lilypond_notation(4), 'f4:maj7')
+        self.assertEqual(Chord(Note('G'), 'aug7').lilypond_notation(8), 'g8:aug7')
+        self.assertEqual(Chord(Note('A'), 'dim7').lilypond_notation(16), 'a16:dim7')
+        self.assertEqual(Chord(Note('B'), 'sus2').lilypond_notation('2.'), 'b2.:sus2')
+        self.assertEqual(Chord(Note('C'), 'sus4').lilypond_notation('4.'), 'c4.:sus4')
+        self.assertEqual(Chord(Note('D'), 'aug').lilypond_notation('8.'), 'd8.:aug')
+        self.assertEqual(Chord(Note('E'), 'dim').lilypond_notation('16.'), 'e16.:dim')
 
     def test_lilypond_mod_same(self):
         """Tests LilyPond chord notation where the Musthe and LilyPond chord
         modifiers are the same.
         """
-        self.assertEqual(Chord(Note('C'), 'aug').lilypond_notation(duration=1), 'c1:aug')
-        self.assertEqual(Chord(Note('B'), 'dim').lilypond_notation(duration=2), 'b2:dim')
         self.assertEqual(Chord(Note('A'), 'maj7').lilypond_notation(), 'a:maj7')
+        self.assertEqual(Chord(Note('C'), 'aug').lilypond_notation(1), 'c1:aug')
+        self.assertEqual(Chord(Note('D'), 'dim').lilypond_notation(2), 'd2:dim')
+        self.assertEqual(Chord(Note('E'), 'maj7').lilypond_notation(4), 'e4:maj7')
+        self.assertEqual(Chord(Note('F'), 'aug7').lilypond_notation(8), 'f8:aug7')
+        self.assertEqual(Chord(Note('G'), 'dim7').lilypond_notation(16), 'g16:dim7')
+        self.assertEqual(Chord(Note('A'), 'sus2').lilypond_notation('2.'), 'a2.:sus2')
+        self.assertEqual(Chord(Note('B'), 'sus4').lilypond_notation('4.'), 'b4.:sus4')
 
     def test_lilypond_mod_diff(self):
         """Tests LilyPond chord notation where the Musthe and LilyPond chord
@@ -324,8 +337,24 @@ class TestsForChord(unittest.TestCase):
         self.assertEqual(Chord(Note('C'), 'm7dim5').lilypond_notation(4), 'c4:7.5-')
         self.assertEqual(Chord(Note('C'), 'open5').lilypond_notation("16."), 'c16.:1.5.8')
 
-
-class TestsForScale(unittest.TestCase):
+    def test_lilypond_aliases(self):
+        """Tests expected LilyPond chord notation where a Musthe Chord object is
+        initialized using an alias.
+        """
+        self.assertEqual(Chord(Note('C'), 'M').lilypond_notation(1), 'c1')
+        self.assertEqual(Chord(Note('C#'), 'm').lilypond_notation(2), 'cis2:m')
+        self.assertEqual(Chord(Note('Db'), '+').lilypond_notation(4), 'des4:aug')
+        self.assertEqual(Chord(Note('D'), '°').lilypond_notation(8), 'd8:dim')
+        self.assertEqual(Chord(Note('E'), '7').lilypond_notation(16), 'e16:7')
+        self.assertEqual(Chord(Note('F'), 'm7').lilypond_notation('2.'), 'f2.:m7')
+        self.assertEqual(Chord(Note('G'), 'M7').lilypond_notation('4.'), 'g4.:maj7')
+        self.assertEqual(Chord(Note('A'), '+7').lilypond_notation('8.'), 'a8.:aug7')
+        self.assertEqual(Chord(Note('B'), '7aug5').lilypond_notation('16.'), 'b16.:aug7')
+        self.assertEqual(Chord(Note('C'), '7#5').lilypond_notation(1), 'c1:aug7')
+        self.assertEqual(Chord(Note('C#'), '°7').lilypond_notation(2), 'cis2:7.5-')
+        self.assertEqual(Chord(Note('Db'), 'ø7').lilypond_notation(4), 'des4:7.5-')
+        self.assertEqual(Chord(Note('D'), 'm7b5').lilypond_notation(8), 'd8:7.5-')
+ 
     def test_note_scales(self):
         def test1(root, name, notes):
             self.assertEqual(list(map(str, Scale(Note(root), name).notes)), notes)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -287,6 +287,43 @@ class TestsForChord(unittest.TestCase):
     def test_chord_equality(self):
         self.assertNotEqual(Chord('Cdim'), Chord('Cdim7'))
 
+    def test_lilypond_base(self):
+        """Tests LilyPond chord notation with no accidentals, no modifier, and
+        no duration.
+        """
+        self.assertEqual(Chord(Note('C')).lilypond_notation(), 'c')
+
+    def test_lilypond_duration(self):
+        """Tests LilyPond chord notation with duration values.
+        """
+        self.assertEqual(Chord(Note('C')).lilypond_notation(4), 'c4')
+        self.assertEqual(Chord(Note('D')).lilypond_notation(duration=4), 'd4')
+        self.assertEqual(Chord(Note('E')).lilypond_notation(duration='8.'), 'e8.')
+
+    def test_lilypond_accidentals(self):
+        """Tests LilyPond chord notation with accidentals.
+        """
+        self.assertEqual(Chord(Note('G#')).lilypond_notation(), 'gis')
+        self.assertEqual(Chord(Note('Ab')).lilypond_notation(), 'aes')
+
+    def test_lilypond_mod_same(self):
+        """Tests LilyPond chord notation where the Musthe and LilyPond chord
+        modifiers are the same.
+        """
+        self.assertEqual(Chord(Note('C'), 'aug').lilypond_notation(duration=1), 'c1:aug')
+        self.assertEqual(Chord(Note('B'), 'dim').lilypond_notation(duration=2), 'b2:dim')
+        self.assertEqual(Chord(Note('A'), 'maj7').lilypond_notation(), 'a:maj7')
+
+    def test_lilypond_mod_diff(self):
+        """Tests LilyPond chord notation where the Musthe and LilyPond chord
+        modifiers are different.
+        """
+        self.assertEqual(Chord(Note('C'), 'min').lilypond_notation(), 'c:m')
+        self.assertEqual(Chord(Note('C'), 'dom7').lilypond_notation(), 'c:7')
+        self.assertEqual(Chord(Note('C'), 'min7').lilypond_notation(), 'c:m7')
+        self.assertEqual(Chord(Note('C'), 'm7dim5').lilypond_notation(4), 'c4:7.5-')
+        self.assertEqual(Chord(Note('C'), 'open5').lilypond_notation("16."), 'c16.:1.5.8')
+
 
 class TestsForScale(unittest.TestCase):
     def test_note_scales(self):


### PR DESCRIPTION
This PR adds a new `lilypond_notation()` method to the `Chord` class, as well as related unit tests.

It is analagous to the existing `Note.lilypond_notation()` method, but it formats the chord for use in LilyPond's [\chordmode](https://lilypond.org/doc/v2.23/Documentation/notation/chord-mode) context, taking into account differences between chord modifiers used by Musthe vs those used by LilyPond.

**Examples:**
```python
>>> Chord(Note('C')).lilypond_notation()
'c'
>>> Chord(Note('G#'), 'dom7').lilypond_notation(4)
'gis4:7'
>>> Chord(Note('Eb'), 'open5').lilypond_notation('8.')
'ees8.:1.5.8' 
```